### PR TITLE
Update constants and API actions to match backend changes

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -27,8 +27,7 @@ import {
 } from '../../state/parameters/selectors';
 import {
   DEMOGRAPHICS,
-  UNIT_SIZES_AFFORDABILITY,
-  UNIT_SIZES_RENT,
+  HOUSING_TYPES,
   DEFAULT_INCOME,
   MIN_INCOME,
   MAX_INCOME,
@@ -66,7 +65,7 @@ export class App extends React.Component {
           <p className="description">
             <strong>Your Housing Type: </strong>
             <select value={userUnitSize} onChange={event => setUserUnitSize(event.target.value)}>
-              {UNIT_SIZES_RENT.map(size => (
+              {HOUSING_TYPES.map(size => (
                 <option value={size} key={size}>{size}</option>
               ))}
             </select>
@@ -74,7 +73,7 @@ export class App extends React.Component {
           <p className="description">
             <strong>Others Housing Type: </strong>
             <select value={otherUnitSize} onChange={event => setOtherUnitSize(event.target.value)}>
-              {UNIT_SIZES_AFFORDABILITY.map(size => (
+              {HOUSING_TYPES.map(size => (
                 <option value={size} key={size}>{size}</option>
               ))}
             </select>
@@ -102,9 +101,9 @@ App.defaultProps = {
   children: <div />,
   neighborhoodData: {},
   userIncome: DEFAULT_INCOME,
-  userUnitSize: UNIT_SIZES_AFFORDABILITY[0],
+  userUnitSize: HOUSING_TYPES[0],
   otherDemographic: DEMOGRAPHICS[0],
-  otherUnitSize: UNIT_SIZES_AFFORDABILITY[0],
+  otherUnitSize: HOUSING_TYPES[0],
   isLoading: false,
   setUserIncome() {},
   setUserUnitSize() {},

--- a/src/state/parameters/constants.js
+++ b/src/state/parameters/constants.js
@@ -1,13 +1,13 @@
-import { DEMOGRAPHICS, UNIT_SIZES_AFFORDABILITY, DEFAULT_INCOME } from '../../utils/data-constants';
+import { DEMOGRAPHICS, HOUSING_TYPES, DEFAULT_INCOME } from '../../utils/data-constants';
 
 export const INITIAL_USER_STATE = {
   income: DEFAULT_INCOME,
-  unitSize: UNIT_SIZES_AFFORDABILITY[0],
+  unitSize: HOUSING_TYPES[0],
 };
 
 export const INITIAL_OTHER_STATE = {
   demographic: DEMOGRAPHICS[0],
-  unitSize: UNIT_SIZES_AFFORDABILITY[0],
+  unitSize: HOUSING_TYPES[0],
 };
 
 const UPDATE_USER_UNIT_SIZE = 'PARAMETERS/UPDATE_USER_UNIT_SIZE';

--- a/src/state/parameters/parameters.test.js
+++ b/src/state/parameters/parameters.test.js
@@ -29,7 +29,7 @@ describe('parameters selectors', () => {
   describe('getUserUnitSize', () => {
     it('should return the first unit size when unset', () => {
       state = { parameters: {} };
-      expect(selectors.getUserUnitSize(state)).to.eql(constants.UNIT_SIZES_RENT[0]);
+      expect(selectors.getUserUnitSize(state)).to.eql(constants.HOUSING_TYPES[0]);
     });
 
     it('should return the set unit size when the state is set', () => {
@@ -53,7 +53,7 @@ describe('parameters selectors', () => {
   describe('getOtherUnitSize', () => {
     it('should return the first unit size when unset', () => {
       state = { parameters: {} };
-      expect(selectors.getOtherUnitSize(state)).to.eql(constants.UNIT_SIZES_AFFORDABILITY[0]);
+      expect(selectors.getOtherUnitSize(state)).to.eql(constants.HOUSING_TYPES[0]);
     });
 
     it('should return the set unit size when the state is set', () => {

--- a/src/state/parameters/selectors.js
+++ b/src/state/parameters/selectors.js
@@ -2,9 +2,8 @@ import { createSelector } from 'reselect';
 import { propOr, path } from 'ramda';
 import {
   DEMOGRAPHICS,
-  UNIT_SIZES_AFFORDABILITY,
+  HOUSING_TYPES,
   DEFAULT_INCOME,
-  UNIT_SIZES_RENT,
 } from '../../utils/data-constants';
 
 export const getUserState = state => path(['parameters', 'user'], state);
@@ -28,7 +27,7 @@ export const getUserIncome = createSelector(
 
 export const getUserUnitSize = createSelector(
   getUserParameters,
-  propOr(UNIT_SIZES_RENT[0], 'unitSize'),
+  propOr(HOUSING_TYPES[0], 'unitSize'),
 );
 
 export const getOtherDemographic = createSelector(
@@ -38,5 +37,5 @@ export const getOtherDemographic = createSelector(
 
 export const getOtherUnitSize = createSelector(
   getOtherParameters,
-  propOr(UNIT_SIZES_AFFORDABILITY[0], 'unitSize'),
+  propOr(HOUSING_TYPES[0], 'unitSize'),
 );

--- a/src/state/rent/actions.js
+++ b/src/state/rent/actions.js
@@ -11,8 +11,8 @@ export const fetchRentData = api('/rent', {
   start: rentStart,
   success: rentSuccess,
   fail: rentFail,
-  normalizer: json => json.map(({ nh_id, rent_amt }) => ({
-    id: nh_id,
+  normalizer: json => json.map(({ NP_ID, rent_amt }) => ({
+    id: NP_ID,
     rent_amt,
   })),
   buildParams: state => ({

--- a/src/state/rent/rent.test.js
+++ b/src/state/rent/rent.test.js
@@ -42,7 +42,7 @@ describe('rent actions', () => {
   });
 
   describe('rent fetch thunk', () => {
-    const commonRentRequest = '/rent?format=json&housing_size=Overall';
+    const commonRentRequest = '/rent?format=json&housing_size=Homeownership';
     let store;
 
     beforeEach(() => {
@@ -55,7 +55,7 @@ describe('rent actions', () => {
       const mockRentResponse = [
         {
           housing_size: 'Overall',
-          nh_id: 1,
+          NP_ID: 1,
           nh_name: '122nd-Division',
           rent_amt: 917,
           year: 2016,

--- a/src/utils/data-constants.js
+++ b/src/utils/data-constants.js
@@ -14,16 +14,8 @@ export const DEMOGRAPHICS = [
   'Foreign-Born',
 ];
 
-export const UNIT_SIZES_AFFORDABILITY = [
+export const HOUSING_TYPES = [
   'Homeownership',
-  'Studio',
-  '1-BR',
-  '2-BR',
-  '3-BR',
-];
-
-export const UNIT_SIZES_RENT = [
-  'Overall',
   'Studio',
   '1-BR',
   '2-BR',


### PR DESCRIPTION
Tiny change. Consolidates 'UNIT_SIZES' to 'HOUSING_TYPES' since they're the same now, updates api data normalizing for Jay's backend change