### PR TITLE
Leaflet crosshatch pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "express": "4.14.0",
     "invariant": "2.2.2",
     "isomorphic-fetch": "2.2.1",
+    "leaflet": "^1.0.3",
     "query-string": "^4.3.3",
     "ramda": "0.23.0",
     "react": "15.4.1",

--- a/src/components/CrossHatch/CrossHatch.test.js
+++ b/src/components/CrossHatch/CrossHatch.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import L from 'leaflet';
+import './leafletCrosshatch';
+
+import CrossHatch from './index';
+
+describe('<CrossHatch />', () => {
+  let map;
+  let wrapper;
+
+  beforeEach(() => {
+    map = {
+      addPattern: sinon.spy(),
+    };
+
+    wrapper = shallow(
+      <CrossHatch />,
+      { context: { map } },
+    );
+  });
+
+  it('should render nothing', () => {
+    expect(wrapper.type()).to.be.null;
+  });
+
+  it('should register a CrossHatch pattern with the map provided as context', () => {
+    expect(map.addPattern).to.have.been.called;
+    expect(map.addPattern.args[0][0]).to.be.an.instanceOf(L.CrossHatch);
+  });
+});

--- a/src/components/CrossHatch/index.js
+++ b/src/components/CrossHatch/index.js
@@ -1,59 +1,27 @@
-import React, { Component, PropTypes } from 'react';
+import { Component, PropTypes } from 'react';
 import L, { Map } from 'leaflet';
-import '../../externals/leafletPattern';
+import './leafletCrosshatch';
 
-L.CrossHatch = L.Pattern.extend({
+/**
+ * Make new raw-leaflet crosshatch pattern with default settings.
+ * Needs to be exported so that the object itself can be used when specifying
+ * fillPattern in leaflet Path options (I guess it selects it by some internal id system?)
+ */
+export const crossHatch = new L.CrossHatch();
 
-  options: {
-    weight: 1,
-    color: 'white',
-    opacity: 1.0,
-    width: 10,
-    height: 10,
-  },
-
-  _addShapes() {
-    this._left = new L.PatternPath({
-      stroke: true,
-      weight: this.options.weight,
-      color: this.options.color,
-      opacity: this.options.opacity,
-    });
-
-    this._right = new L.PatternPath({
-      stroke: true,
-      weight: this.options.weight,
-      color: this.options.color,
-      opacity: this.options.opacity,
-    });
-
-    this.addShape(this._left);
-    this.addShape(this._right);
-
-    this._update();
-  },
-
-  _update() {
-    this._left.options.d = `M0,0 l${this.options.width},${this.options.height}`;
-    this._right.options.d = `M${this.options.width},0 l-${this.options.width},${this.options.height}`;
-  },
-
-  setStyle: L.Pattern.prototype.setStyle,
-});
-
-export const crossHatch = new L.CrossHatch({
-  weight: 1,
-  color: 'black',
-  opacity: 1.0,
-});
-
+/**
+ * React-Leaflet exposes the raw-leaflet map object as context to all child components
+ * The entire purpose of this component is to access this object and register
+ * the crossHatch pattern. Hence, it renders nothing. In order for crosshatch pattern to be
+ * used, this should be included within leaflet map component
+ */
 class CrossHatch extends Component {
   componentWillMount() {
     crossHatch.addTo(this.context.map);
   }
 
   render() {
-    return <div>Taco</div>;
+    return null;
   }
 }
 

--- a/src/components/CrossHatch/index.js
+++ b/src/components/CrossHatch/index.js
@@ -1,0 +1,64 @@
+import React, { Component, PropTypes } from 'react';
+import L, { Map } from 'leaflet';
+import '../../externals/leafletPattern';
+
+L.CrossHatch = L.Pattern.extend({
+
+  options: {
+    weight: 1,
+    color: 'white',
+    opacity: 1.0,
+    width: 10,
+    height: 10,
+  },
+
+  _addShapes() {
+    this._left = new L.PatternPath({
+      stroke: true,
+      weight: this.options.weight,
+      color: this.options.color,
+      opacity: this.options.opacity,
+    });
+
+    this._right = new L.PatternPath({
+      stroke: true,
+      weight: this.options.weight,
+      color: this.options.color,
+      opacity: this.options.opacity,
+    });
+
+    this.addShape(this._left);
+    this.addShape(this._right);
+
+    this._update();
+  },
+
+  _update() {
+    this._left.options.d = `M0,0 l${this.options.width},${this.options.height}`;
+    this._right.options.d = `M${this.options.width},0 l-${this.options.width},${this.options.height}`;
+  },
+
+  setStyle: L.Pattern.prototype.setStyle,
+});
+
+export const crossHatch = new L.CrossHatch({
+  weight: 1,
+  color: 'black',
+  opacity: 1.0,
+});
+
+class CrossHatch extends Component {
+  componentWillMount() {
+    crossHatch.addTo(this.context.map);
+  }
+
+  render() {
+    return <div>Taco</div>;
+  }
+}
+
+CrossHatch.contextTypes = {
+  map: PropTypes.instanceOf(Map),
+};
+
+export default CrossHatch;

--- a/src/components/CrossHatch/leafletCrosshatch.js
+++ b/src/components/CrossHatch/leafletCrosshatch.js
@@ -13,7 +13,7 @@ L.CrossHatch = L.Pattern.extend({
    * to constructor
    */
   options: {
-    weight: 0.7,
+    weight: 0.5,
     color: 'white',
     opacity: 1.0,
     width: 10,

--- a/src/components/CrossHatch/leafletCrosshatch.js
+++ b/src/components/CrossHatch/leafletCrosshatch.js
@@ -13,7 +13,7 @@ L.CrossHatch = L.Pattern.extend({
    * to constructor
    */
   options: {
-    weight: 1,
+    weight: 0.7,
     color: 'white',
     opacity: 1.0,
     width: 10,

--- a/src/components/CrossHatch/leafletCrosshatch.js
+++ b/src/components/CrossHatch/leafletCrosshatch.js
@@ -1,0 +1,71 @@
+import L from 'leaflet';
+import '../../externals/leafletPattern';
+
+/**
+ * This builds a CrossHatch svg pattern generator and registers it with
+ * Leaflet following the pattern from the leaflet.Pattern extension
+ * @see https://github.com/teastman/Leaflet.pattern
+ */
+L.CrossHatch = L.Pattern.extend({
+
+  /**
+   * Default options for crosshatch pattern. Will be overriden by anything passed
+   * to constructor
+   */
+  options: {
+    weight: 1,
+    color: 'white',
+    opacity: 1.0,
+    width: 10,
+    height: 10,
+  },
+
+  /**
+   * This method gets called when the pattern is added to a leaflet map instance
+   */
+  _addShapes() {
+    /**
+     * Left leaning stripe pattern
+     */
+    this._left = new L.PatternPath({
+      stroke: true,
+      weight: this.options.weight,
+      color: this.options.color,
+      opacity: this.options.opacity,
+    });
+
+    /**
+     * Right leaning strip pattern
+     */
+    this._right = new L.PatternPath({
+      stroke: true,
+      weight: this.options.weight,
+      color: this.options.color,
+      opacity: this.options.opacity,
+    });
+
+    /**
+     * Registers shapes with pattern instance
+     */
+    this.addShape(this._left);
+    this.addShape(this._right);
+
+    /**
+     * Initially calls _update to set svg path based on options
+     */
+    this._update();
+  },
+
+  /**
+   * this gets called internally somewhere, who knows. Draws two lines from corner to corner
+   */
+  _update() {
+    this._left.options.d = `M0,0 l${this.options.width},${this.options.height}`;
+    this._right.options.d = `M${this.options.width},0 l-${this.options.width},${this.options.height}`;
+  },
+
+  /**
+   * Did this becuase the examples did it, not sure why it's needed
+   */
+  setStyle: L.Pattern.prototype.setStyle,
+});

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import LeafletMap from '@hackoregon/component-library/lib/LeafletMap/LeafletMap';
 import Neighborhood from '../Neighborhood';
+import CrossHatch from '../CrossHatch';
 
 const portlandBounds = [
   [45.654527, -122.464291],
@@ -30,6 +31,7 @@ const Map = ({ neighborhoods }) => (
             data={neighborhood}
           />,
         )}
+        <CrossHatch />
       </LeafletMap>
     }
   </div>

--- a/src/components/Neighborhood/index.js
+++ b/src/components/Neighborhood/index.js
@@ -38,7 +38,7 @@ const Neighborhood = ({ data, onClick }) => (
 
 Neighborhood.propTypes = {
   data: PropTypes.object.isRequired,
-  onClick: PropTypes.function,
+  onClick: PropTypes.func.isRequired,
 };
 
 Neighborhood.defaultProps = {

--- a/src/components/Neighborhood/index.js
+++ b/src/components/Neighborhood/index.js
@@ -1,20 +1,18 @@
 import React, { PropTypes } from 'react';
 import { GeoJSON, Popup } from 'react-leaflet';
+import { crossHatch } from '../CrossHatch';
 
 /**
  * This function is where we can style the geoJson based on data.
  * We have available the properties described here: http://leafletjs.com/reference.html#path-options
  */
-const setPathOptions = ({ affordableYou, affordableOther }) => ({
-  opacity: affordableOther ? '1' : '0',
-  fillOpacity: 0.7,
-  fillColor: affordableYou ? '#386598' : '#CFE7F9',
-  color: 'black',
+const setOtherPathOptions = () => ({
+  fillPattern: crossHatch,
 });
 
 const Neighborhood = ({ data }) => (
-  <GeoJSON data={data} {...setPathOptions(data)} >
-    <Popup><div>{data.name}</div></Popup>
+  <GeoJSON data={data} {...setOtherPathOptions(data)}>
+    <Popup>{data.name}</Popup>
   </GeoJSON>
 );
 

--- a/src/components/Neighborhood/index.js
+++ b/src/components/Neighborhood/index.js
@@ -1,23 +1,48 @@
 import React, { PropTypes } from 'react';
-import { GeoJSON, Popup } from 'react-leaflet';
+import { GeoJSON, LayerGroup } from 'react-leaflet';
 import { crossHatch } from '../CrossHatch';
 
+const NEIGHBORHOOD_OPACITY = 0.7;
+const NOT_AFFORDABLE_COLOR = '#A5B8C7';
+const AFFORDABLE_COLOR = '#386598';
+
 /**
- * This function is where we can style the geoJson based on data.
+ * These functions are where we can style the geoJson based on data.
  * We have available the properties described here: http://leafletjs.com/reference.html#path-options
  */
-const setOtherPathOptions = () => ({
+const setOtherPathOptions = ({ affordableOther }) => ({
+  fillOpacity: affordableOther ? 1 : 0,
+  opacity: 0,
   fillPattern: crossHatch,
 });
 
-const Neighborhood = ({ data }) => (
-  <GeoJSON data={data} {...setOtherPathOptions(data)}>
-    <Popup>{data.name}</Popup>
-  </GeoJSON>
+const setYouPathOptions = ({ affordableYou }) => ({
+  opacity: NEIGHBORHOOD_OPACITY,
+  weight: 1,
+  fillOpacity: NEIGHBORHOOD_OPACITY,
+  fillColor: affordableYou ? AFFORDABLE_COLOR : NOT_AFFORDABLE_COLOR,
+  color: affordableYou ? AFFORDABLE_COLOR : NOT_AFFORDABLE_COLOR,
+});
+
+/**
+ * Neighborhood component now renders two geojson layers superimposed on one another
+ * CrossHatch 'affordableOther' representation is rendered second, therefore it has precedence
+ * and will receive mouse events. Click event is propagated up
+ */
+const Neighborhood = ({ data, onClick }) => (
+  <LayerGroup>
+    <GeoJSON data={data} {...setYouPathOptions(data)} />
+    <GeoJSON data={data} {...setOtherPathOptions(data)} onClick={onClick} />
+  </LayerGroup>
 );
 
 Neighborhood.propTypes = {
   data: PropTypes.object.isRequired,
+  onClick: PropTypes.function,
+};
+
+Neighborhood.defaultProps = {
+  onClick: () => {},
 };
 
 export default Neighborhood;

--- a/src/components/Neighborhood/index.js
+++ b/src/components/Neighborhood/index.js
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
 import { GeoJSON, LayerGroup } from 'react-leaflet';
 import { crossHatch } from '../CrossHatch';
+import { HOUSING_TEAM_PRIMARY_COLOR } from '../../utils/data-constants';
 
-const NEIGHBORHOOD_OPACITY = 0.7;
-const NOT_AFFORDABLE_COLOR = '#A5B8C7';
-const AFFORDABLE_COLOR = '#386598';
+const NEIGHBORHOOD_OPACITY = 0.8;
+const NOT_AFFORDABLE_COLOR = '#9A9D9F'; // color chosen from the style guide, was contrasted with our primary in a pie chart
+const AFFORDABLE_COLOR = HOUSING_TEAM_PRIMARY_COLOR;
 
 /**
  * These functions are where we can style the geoJson based on data.

--- a/src/externals/leafletPattern.js
+++ b/src/externals/leafletPattern.js
@@ -1,0 +1,507 @@
+/*
+ Leaflet.pattern, Provides tools to set the backgrounds of vector shapes in Leaflet to be patterns.
+ https://github.com/teastman/Leaflet.pattern
+ (c) 2015, Tyler Eastman
+*/
+
+import L from 'leaflet';
+
+/* eslint-disable */
+(function (window, document, undefined) {/*
+ * L.Pattern is the base class for fill patterns for leaflet Paths.
+ */
+
+L.Pattern = L.Class.extend({
+	includes: [L.Mixin.Events],
+
+	options: {
+		x: 0,
+		y: 0,
+		width: 8,
+		height: 8,
+		patternUnits: 'userSpaceOnUse',
+		patternContentUnits: 'userSpaceOnUse'
+		// angle: <0 - 360>
+		// patternTransform: <transform-list>
+	},
+
+	_addShapes: L.Util.falseFn,
+	_update: L.Util.falseFn,
+
+	initialize: function (options) {
+		this._shapes = {};
+		L.setOptions(this, options);
+	},
+
+	onAdd: function (map) {
+        this._map = map.target ? map.target : map;
+        this._map._initDefRoot();
+
+		// Create the DOM Object for the pattern.
+		this._initDom();
+
+		// Any shapes that were added before this was added to the map need to have their onAdd called.
+		for (var i in this._shapes) {
+			this._shapes[i].onAdd(this);
+		}
+
+		// Call any children that want to add their own shapes.
+		this._addShapes();
+
+		// Add the DOM Object to the DOM Tree
+		this._addDom();
+		this.redraw();
+
+		if (this.getEvents) {
+            this._map.on(this.getEvents(), this);
+		}
+		this.fire('add');
+        this._map.fire('patternadd', {pattern: this});
+	},
+
+	onRemove: function () {
+		this._removeDom();
+	},
+
+	redraw: function () {
+		if (this._map) {
+			this._update();
+			for (var i in this._shapes) {
+				this._shapes[i].redraw();
+			}
+		}
+		return this;
+	},
+
+	setStyle: function (style) {
+		L.setOptions(this, style);
+		if (this._map) {
+			this._updateStyle();
+			this.redraw();
+		}
+		return this;
+	},
+
+	addTo: function (map) {
+		map.addPattern(this);
+		return this;
+	},
+
+	remove: function () {
+		return this.removeFrom(this._map);
+	},
+
+	removeFrom: function (map) {
+		if (map) {
+			map.removePattern(this);
+		}
+		return this;
+	}
+});
+
+L.Map.addInitHook(function () {
+	this._patterns = {};
+});
+
+L.Map.include({
+	addPattern: function (pattern) {
+		var id = L.stamp(pattern);
+		if (this._patterns[id]) { return pattern; }
+		this._patterns[id] = pattern;
+
+		this.whenReady(pattern.onAdd, pattern);
+		return this;
+	},
+
+	removePattern: function (pattern) {
+		var id = L.stamp(pattern);
+		if (!this._patterns[id]) { return this; }
+
+		if (this._loaded) {
+			pattern.onRemove(this);
+		}
+
+		if (pattern.getEvents) {
+			this.off(pattern.getEvents(), pattern);
+		}
+
+		delete this._patterns[id];
+
+		if (this._loaded) {
+			this.fire('patternremove', {pattern: pattern});
+			pattern.fire('remove');
+		}
+
+		pattern._map = null;
+		return this;
+	},
+
+	hasPattern: function (pattern) {
+		return !!pattern && (L.stamp(pattern) in this._patterns);
+	}
+});
+
+
+
+L.Pattern.SVG_NS = 'http://www.w3.org/2000/svg';
+
+L.Pattern = L.Pattern.extend({
+	_createElement: function (name) {
+		return document.createElementNS(L.Pattern.SVG_NS, name);
+	},
+
+	_initDom: function () {
+		this._dom = this._createElement('pattern');
+		if (this.options.className) {
+			L.DomUtil.addClass(this._dom, this.options.className);
+		}
+		this._updateStyle();
+	},
+
+	_addDom: function () {
+		this._map._defRoot.appendChild(this._dom);
+	},
+
+	_removeDom: function () {
+		L.DomUtil.remove(this._dom);
+	},
+
+	_updateStyle: function () {
+		var dom = this._dom,
+			options = this.options;
+
+		if (!dom) { return; }
+
+		dom.setAttribute('id', L.stamp(this));
+		dom.setAttribute('x', options.x);
+		dom.setAttribute('y', options.y);
+		dom.setAttribute('width', options.width);
+		dom.setAttribute('height', options.height);
+		dom.setAttribute('patternUnits', options.patternUnits);
+		dom.setAttribute('patternContentUnits', options.patternContentUnits);
+
+		if (options.patternTransform || options.angle) {
+			var transform = options.patternTransform ? options.patternTransform + " " : "";
+			transform += options.angle ?  "rotate(" + options.angle + ") " : "";
+			dom.setAttribute('patternTransform', transform);
+		}
+		else {
+			dom.removeAttribute('patternTransform');
+		}
+
+		for (var i in this._shapes) {
+			this._shapes[i]._updateStyle();
+		}
+	}
+});
+
+L.Map.include({
+	_initDefRoot: function () {
+        if (!this._defRoot) {
+            if (typeof this.getRenderer === 'function') {
+                var renderer = this.getRenderer(this);
+                this._defRoot = L.Pattern.prototype._createElement('defs');
+                renderer._container.appendChild(this._defRoot);
+            } else {
+                if (!this._pathRoot) {
+                    this._initPathRoot();
+                }
+                this._defRoot = L.Pattern.prototype._createElement('defs');
+                this._pathRoot.appendChild(this._defRoot);
+            }
+        }
+    }
+});
+
+if (L.SVG) {
+    L.SVG.include({
+        _superUpdateStyle: L.SVG.prototype._updateStyle,
+
+        _updateStyle: function (layer) {
+            this._superUpdateStyle(layer);
+
+            if (layer.options.fill && layer.options.fillPattern) {
+                layer._path.setAttribute('fill', 'url(#' + L.stamp(layer.options.fillPattern) + ")");
+            }
+        }
+    });
+}
+else {
+    L.Path.include({
+        _superUpdateStyle: L.Path.prototype._updateStyle,
+
+        _updateStyle: function () {
+            this._superUpdateStyle();
+
+            if (this.options.fill && this.options.fillPattern) {
+                this._path.setAttribute('fill', 'url(#' + L.stamp(this.options.fillPattern) + ")");
+            }
+        }
+    });
+}
+
+
+/*
+ * L.StripePattern is an implementation of Pattern that creates stripes.
+ */
+
+L.StripePattern = L.Pattern.extend({
+
+	options: {
+		weight: 4,
+		spaceWeight: 4,
+		color: '#000000',
+		spaceColor: '#ffffff',
+		opacity: 1.0,
+		spaceOpacity: 0.0
+	},
+
+	_addShapes: function () {
+		this._stripe = new L.PatternPath({
+			stroke: true,
+			weight: this.options.weight,
+			color: this.options.color,
+			opacity: this.options.opacity
+		});
+
+		this._space = new L.PatternPath({
+			stroke: true,
+			weight: this.options.spaceWeight,
+			color: this.options.spaceColor,
+			opacity: this.options.spaceOpacity
+		});
+
+		this.addShape(this._stripe);
+		this.addShape(this._space);
+
+		this._update();
+	},
+
+	_update: function () {
+		this._stripe.options.d = 'M0 ' + this._stripe.options.weight / 2 + ' H ' + this.options.width;
+		this._space.options.d = 'M0 ' + (this._stripe.options.weight + this._space.options.weight / 2) + ' H ' + this.options.width;
+	},
+
+	setStyle: L.Pattern.prototype.setStyle
+});
+
+L.stripePattern = function (options) {
+	return new L.StripePattern(options);
+};
+
+/*
+ * L.PatternShape is the base class that is used to define the shapes in Patterns.
+ */
+
+L.PatternShape = L.Class.extend({
+
+	options: {
+		stroke: true,
+		color: '#3388ff',
+		weight: 3,
+		opacity: 1,
+		lineCap: 'round',
+		lineJoin: 'round',
+		// dashArray: null
+		// dashOffset: null
+
+		// fill: false
+		// fillColor: same as color by default
+		fillOpacity: 0.2,
+		fillRule: 'evenodd',
+		// fillPattern: L.Pattern
+	},
+
+	initialize: function (options) {
+		L.setOptions(this, options);
+	},
+
+	// Called when the parent Pattern get's added to the map,
+	// or when added to a Pattern that is already on the map.
+	onAdd: function (pattern) {
+		this._pattern = pattern;
+		if (this._pattern._dom) {
+			this._initDom();  // This function is implemented by it's children.
+			this._addDom();
+		}
+	},
+
+	addTo: function (pattern) {
+		pattern.addShape(this);
+		return this;
+	},
+
+	redraw: function () {
+		if (this._pattern) {
+			this._updateShape();  // This function is implemented by it's children.
+		}
+		return this;
+	},
+
+	setStyle: function (style) {
+		L.setOptions(this, style);
+		if (this._pattern) {
+			this._updateStyle();
+		}
+		return this;
+	},
+
+	setShape: function (shape) {
+        this.options = L.extend({}, this.options, shape);
+		this._updateShape();
+	},
+});
+
+L.Pattern.include({
+	addShape: function (shape) {
+		var id = L.stamp(shape);
+		if (this._shapes[id]) { return shape; }
+		this._shapes[id] = shape;
+		shape.onAdd(this);
+	}
+});
+
+
+
+L.PatternShape.SVG_NS = 'http://www.w3.org/2000/svg';
+
+L.PatternShape = L.PatternShape.extend({
+	_createElement: function (name) {
+		return document.createElementNS(L.PatternShape.SVG_NS, name);
+	},
+
+	_initDom: L.Util.falseFn,
+	_updateShape: L.Util.falseFn,
+
+	_initDomElement: function (type) {
+		this._dom = this._createElement(type);
+		if (this.options.className) {
+			L.DomUtil.addClass(this._dom, this.options.className);
+		}
+		this._updateStyle();
+	},
+
+	_addDom: function () {
+		this._pattern._dom.appendChild(this._dom);
+	},
+
+	_updateStyle: function () {
+		var dom = this._dom,
+			options = this.options;
+
+		if (!dom) { return; }
+
+		if (options.stroke) {
+			dom.setAttribute('stroke', options.color);
+			dom.setAttribute('stroke-opacity', options.opacity);
+			dom.setAttribute('stroke-width', options.weight);
+			dom.setAttribute('stroke-linecap', options.lineCap);
+			dom.setAttribute('stroke-linejoin', options.lineJoin);
+
+			if (options.dashArray) {
+				dom.setAttribute('stroke-dasharray', options.dashArray);
+			} else {
+				dom.removeAttribute('stroke-dasharray');
+			}
+
+			if (options.dashOffset) {
+				dom.setAttribute('stroke-dashoffset', options.dashOffset);
+			} else {
+				dom.removeAttribute('stroke-dashoffset');
+			}
+		} else {
+			dom.setAttribute('stroke', 'none');
+		}
+
+		if (options.fill) {
+			if (options.fillPattern) {
+				dom.setAttribute('fill', 'url(#' + L.stamp(options.fillPattern) + ")");
+			}
+			else {
+				dom.setAttribute('fill', options.fillColor || options.color);
+			}
+			dom.setAttribute('fill-opacity', options.fillOpacity);
+			dom.setAttribute('fill-rule', options.fillRule || 'evenodd');
+		} else {
+			dom.setAttribute('fill', 'none');
+		}
+
+		dom.setAttribute('pointer-events', options.pointerEvents || (options.interactive ? 'visiblePainted' : 'none'));
+	}
+});
+
+
+
+/*
+ * L.PatternPath is the implementation of PatternShape for adding Paths
+ */
+
+L.PatternPath = L.PatternShape.extend({
+//	options: {
+		// d: <svg path code>
+//	},
+
+	_initDom: function () {
+		this._initDomElement('path');
+	},
+
+	_updateShape: function () {
+        if (!this._dom) { return; }
+		this._dom.setAttribute('d', this.options.d);
+	}
+});
+
+/*
+ * L.PatternCircle is the implementation of PatternShape for adding Circles
+ */
+
+L.PatternCircle = L.PatternShape.extend({
+	options: {
+        x: 0,
+        y: 0,
+        radius: 0
+	},
+
+	_initDom: function () {
+		this._initDomElement('circle');
+	},
+
+	_updateShape: function () {
+        if (!this._dom) { return; }
+		this._dom.setAttribute('cx', this.options.x);
+		this._dom.setAttribute('cy', this.options.y);
+		this._dom.setAttribute('r', this.options.radius);
+	}
+});
+
+/*
+ * L.PatternRect is the implementation of PatternShape for adding Rectangles
+ */
+
+L.PatternRect = L.PatternShape.extend({
+	options: {
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        // rx: x radius for rounded corners
+        // ry: y radius for rounded corners
+	},
+
+	_initDom: function () {
+		this._initDomElement('rect');
+	},
+
+	_updateShape: function () {
+        if (!this._dom) { return; }
+		this._dom.setAttribute('x', this.options.x);
+		this._dom.setAttribute('y', this.options.y);
+		this._dom.setAttribute('width', this.options.width);
+		this._dom.setAttribute('height', this.options.height);
+        if (this.options.rx) { this._dom.setAttribute('rx', this.options.rx); }
+		if (this.options.ry) { this._dom.setAttribute('ry', this.options.ry); }
+	}
+});
+
+}(window, document));
+/* eslint-enable */

--- a/src/utils/data-constants.js
+++ b/src/utils/data-constants.js
@@ -27,3 +27,5 @@ export const HOUSING_TYPES = [
 export const DEFAULT_INCOME = 25;
 export const MIN_INCOME = 9.75;
 export const MAX_INCOME = 75;
+
+export const HOUSING_TEAM_PRIMARY_COLOR = '#3e75ac';


### PR DESCRIPTION
Addresses #27 if we decide it is readable enough. 

Some coding notes: 

- To implement svg pattern fills on our neighborhoods GeoJSON, I used this [leaflet.Pattern](https://github.com/teastman/Leaflet.pattern) plugin. Despite being pretty well written in general and being maintained within the last year, this plugin is inexplicably not on npm. I had to copy it in at src/externals/leafletPattern.js.

- To use svg pattern fills with leaflet via this plugin, you need to first 'register' the pattern with the map, then also set the `fillContent` option for your geoJSON path equal to that pattern object. I made a custom crossHatch pattern in `src/Components/CrossHatch/leafletCrosshatch.js` to be instantiated and exported. The `CrossHatch` component grabs the underlying leaflet map object provided by React-Leaflet as context and registers an instance of this pattern with it. It should be included in the map to work correctly.

- The color, weight, and spacing of the hatch is adjustable so we can fiddle with it.


<img width="1189" alt="screen shot 2017-04-28 at 10 27 54 am" src="https://cloud.githubusercontent.com/assets/6165476/25539826/c96d5444-2bfd-11e7-94eb-c8348c62e600.png">
