### PR TITLE
Ensure that affordability data comes from the 2016 reporting year

### DIFF
--- a/src/state/affordability/actions.js
+++ b/src/state/affordability/actions.js
@@ -11,9 +11,10 @@ export const fetchAffordabilityData = api('/affordable', {
   start: affordabilityStart,
   success: affordabilitySuccess,
   fail: affordabilityFail,
-  normalizer: json => json.map(({ affordable, NP_ID }) => ({
+  normalizer: json => json.map(({ affordable, NP_ID, year }) => ({
     id: NP_ID,
     affordable,
+    year,
   })),
   buildParams: state => ({
     housing_size: getOtherUnitSize(state),

--- a/src/state/affordability/affordability.test.js
+++ b/src/state/affordability/affordability.test.js
@@ -63,6 +63,7 @@ describe('affordability actions', () => {
           housing_size: '1-BR',
           neighborhood: 'Centennial-Glenfair-Wilkes',
           NP_ID: 10,
+          year: 2016,
         },
       ];
 
@@ -77,6 +78,7 @@ describe('affordability actions', () => {
           payload: [{
             affordable: true,
             id: 10,
+            year: 2016,
           }],
         },
       ];
@@ -232,9 +234,23 @@ describe('affordability selectors', () => {
     });
 
     it('should return affordability data when set', () => {
-      const data = 'you found it!';
+      const data = [
+        { year: 2016, affordable: true, id: 1 },
+        { year: 2016, affordable: true, id: 2 },
+        { year: 2016, affordable: true, id: 3 },
+      ];
       state = { affordability: { data } };
       expect(selectors.getAffordabilityData(state)).to.eql(data);
+    });
+
+    it('should filter out any affordability data for years other than 2016', () => {
+      const data = [
+        { year: 2016, affordable: true, id: 1 },
+        { year: 2015, affordable: true, id: 2 },
+        { year: 2017, affordable: true, id: 3 },
+      ];
+      state = { affordability: { data } };
+      expect(selectors.getAffordabilityData(state)).to.eql([data[0]]);
     });
   });
 });

--- a/src/state/affordability/selectors.js
+++ b/src/state/affordability/selectors.js
@@ -11,7 +11,7 @@ export const getAffordabilityRequest = createSelector(
 
 export const getAffordabilityData = createSelector(
   getAffordabilityRequest,
-  ({ data }) => data,
+  ({ data }) => data && data.filter(({ year }) => year === 2016),
 );
 
 export const isAffordabilityPending = createSelector(

--- a/src/state/globalSelectors.test.js
+++ b/src/state/globalSelectors.test.js
@@ -58,7 +58,7 @@ describe('globalSelectors', () => {
     it('should associate data by neighborhood id', () => {
       const state = {
         neighborhoods: { data: [{ name: 'My hood', id: 1, type: 'Feature' }] },
-        affordability: { data: [{ id: 1, affordable: true }] },
+        affordability: { data: [{ id: 1, affordable: true, year: 2016 }] },
         rent: { data: [{ id: 1, rent_amt: 10000000 }] },
         parameters: { user: { income: 40000 } },
       };


### PR DESCRIPTION
The affordability endpoint returns data for both 2015 and 2016. To ensure that we are getting data for 2016 instead of 2015 (or even worse: a mix of both) I added a filter to the affordability selector.